### PR TITLE
docs: Mention RTX_* env vars are no longer read

### DIFF
--- a/docs/rtx.md
+++ b/docs/rtx.md
@@ -8,7 +8,7 @@ migrate its internal directories, moving `~/.local/share/rtx` to `~/.local/share
 and `~/.config/rtx` to `~/.config/mise` (if the destination does not exist).
 
 `mise` will continue reading `.rtx.toml` files for some time but that eventually will
-be deprecated so please rename them to `.mise.toml`. `mise` will not read from `MISE_*`
+be deprecated so please rename them to `.mise.toml`. `mise` will not read from `RTX_*`
 env vars so those will need to be changed to `MISE_*`. Anything using a local `.rtx` or
 `.config/rtx` directory will need to be moved to `.mise`/`.config/mise`.
 


### PR DESCRIPTION
Documentation to migrate from `rtx` to `mise` mentioned `mise` does not read from `MISE_*` env vars. This is a typo and change it to `RTX_*`.