### PR TITLE
Ruby installs are also not auto-migrated

### DIFF
--- a/docs/rtx.md
+++ b/docs/rtx.md
@@ -12,8 +12,8 @@ not having done that sooner knowing that this was likely going to be necessary a
 
 To upgrade from `rtx` to `mise`, simply install `mise` and it should automatically
 migrate its internal directories, moving `~/.local/share/rtx/installs/*` to `~/.local/share/mise/installs/*`
-(skipping python which cannot be moved), `~/.local/share/rtx/plugins` to `~/.local/share/mise/plugins`,
-and `~/.config/rtx` to `~/.config/mise` (if the destination does not exist). Python
+(skipping python & ruby which cannot be moved), `~/.local/share/rtx/plugins` to `~/.local/share/mise/plugins`,
+and `~/.config/rtx` to `~/.config/mise` (if the destination does not exist). Python and Ruby
 installs will need to be reinstalled with `mise install`.
 
 `mise` will continue reading `.rtx.toml` files for some time but that eventually will


### PR DESCRIPTION
See code at https://github.com/jdx/mise/blob/49027919665af8a568c60356f8022d757a26e68e/src/migrate.rs#L67-L69 - ensure docs are consistent with the code so anyone who needs to manually migrate can do the right thing :-)

Discussion also at https://github.com/jdx/mise/discussions/1338#discussioncomment-8019456