### PR TITLE
fix: remove remark about Zulu distribution that no longer applies

### DIFF
--- a/docs/lang/java.md
+++ b/docs/lang/java.md
@@ -33,6 +33,4 @@ sudo mkdir /Library/Java/JavaVirtualMachines/openjdk-20.jdk
 sudo ln -s ~/.local/share/mise/installs/java/openjdk-20/Contents /Library/Java/JavaVirtualMachines/openjdk-20.jdk/Contents
 ```
 
-The distribution from Azul Systems does support the integration but the symlink target location will differ from the example above (e.g `~/.local/share/mise/installs/java/zulu-11.64.190/zulu-11.jdk/Contents`).
-
 > Note: Not all distributions of the Java SDK support this integration (e.g liberica).


### PR DESCRIPTION
The remark about Zulu distribution does no longer apply after https://github.com/jdx/mise/pull/1381 has been fixed. 