### PR TITLE
Mention shims approach in an FAQ

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -195,7 +195,15 @@ compatible with asdf. Also consider using `.mise.toml` instead which won't confl
 ### mise isn't working when calling from tmux or another shell initialization script
 
 `mise activate` will not update PATH until the shell prompt is displayed. So if you need to access a
-tool provided by mise before the prompt is displayed you must manually call `hook-env`:
+tool provided by mise before the prompt is displayed you can either
+[add the shims to your PATH](getting-started.html#2-add-mise-shims-to-path) e.g.
+
+```bash
+export PATH="$HOME/.local/share/mise/shims:$PATH"
+python --version # will work after adding shims to PATH
+```
+
+Or you can manually call `hook-env`:
 
 ```bash
 eval "$(mise activate bash)"


### PR DESCRIPTION
While trying to figure out which "expose mise binaries" approach is best for my [`~/.huskyrc` file](https://typicode.github.io/husky/troubleshooting.html#command-not-found) I noticed that in your [What does `mise activate` do?](https://mise.jdx.dev/faq.html#what-does-mise-activate-do) FAQ, that the shims approach is preferable over the `mise hook-env` approach.

But in another FAQ [mise isn't working when calling from tmux or another shell initialization script](https://mise.jdx.dev/faq.html#mise-isn-t-working-when-calling-from-tmux-or-another-shell-initialization-script) this is not mentioned and `mise hook-env` is suggested as the fix.

This PR updates the "mise isn't working when calling from tmux or another shell initialization script" FAQ to iron out this inconsistency, by mentioning the "add shims to path manually" approach since I _think_ that is the recommended approach over `mise hook-env` (I assume it's faster too).

---

bit more info https://github.com/jdx/mise/discussions/734