### PR TITLE
Update dev-tools.md

### DIFF
--- a/docs/dev-tools.md
+++ b/docs/dev-tools.md
@@ -32,7 +32,7 @@ environment variable to point your shell to the correct runtime binaries. When y
 directory containing a `.tool-versions`/`.mise.toml` file, mise will automatically set the
 appropriate tool versions in `PATH`.
 
-::: note
+::: info
 mise does not modify "cd". It actually runs every time the prompt is _displayed_.
 See the [FAQ](/faq#what-does-mise-activate-do).
 :::


### PR DESCRIPTION
Use `::: info` container type instead of `::: note` because VitePress doesn't support `::: note` by default.

ref: https://vitepress.dev/guide/markdown#custom-containers

<details><summary>Screenshot of how it is currently rendered</summary>
<p>

<img width="720" alt="2024-01-10-20 09 54@2x" src="https://github.com/jdx/mise-docs/assets/8270635/6156beb6-ee35-4678-aab6-60ce4a0d991b">

</p>
</details> 

