### PR TITLE
Fix the documentation for Xcode

### DIFF
--- a/ide-integration.md
+++ b/ide-integration.md
@@ -30,7 +30,7 @@ Alternatively, you may be able to get tighter integration with a direnv extensio
 
 ## Xcode
 
-Xcode projects can run system commands from script build phases and schemes. Since Xcode sandboxes the execution of the script using the tool `/usr/bin/sandbox-exec`, don't expect Mise and the automatically-activated tools to work out of the box. First, you'll need to add `$(SRCROOT)/.mise.toml` to the list of **Input files**. This is necessary for Xcode to allow reads to that file. Then, you'll need to run your commands through the `mise x` command, which 
+Xcode projects can run system commands from script build phases and schemes. Since Xcode sandboxes the execution of the script using the tool `/usr/bin/sandbox-exec`, don't expect Mise and the automatically-activated tools to work out of the box. First, you'll need to add `$(SRCROOT)/.mise.toml` to the list of **Input files**. This is necessary for Xcode to allow reads to that file. Then, you'll need to run your commands through the `mise x` command: 
 
 ```bash
 # Add Mise to the PATH

--- a/ide-integration.md
+++ b/ide-integration.md
@@ -30,14 +30,32 @@ Alternatively, you may be able to get tighter integration with a direnv extensio
 
 ## Xcode
 
-Xcode projects can system commands from script build phases and schemes. Since Xcode doesn't source your shell profile the tool versions pinned by your project's Mise configuration file are not automatically resolved through the `$PATH` environment variable.
-To work around this, you can use the `mise x`:
+Xcode projects can run system commands from script build phases and schemes. Since Xcode sandboxes the execution of the script using the tool `/usr/bin/sandbox-exec`, don't expect Mise and the automatically-activated tools to work out of the box. First, you'll need to add `$(SRCROOT)/.mise.toml` to the list of **Input files**. This is necessary for Xcode to allow reads to that file. Then, you'll need to run your commands through the `mise x` command, which 
 
 ```bash
+# Add Mise to the PATH
+export PATH="$HOME/.local/bin/bin:$PATH"
+
+# -C ensures that Mise loads the configuration from the Mise configuration 
+# file in the project's root directory.
 mise x -C $SRCROOT swiftlint
 ```
 
-Note that the `-C` flag ensures that Mise will use the project's root directory, where the Mise configuration file lives, as the working directory for the command. Note that in schemes pre and post action scripts, you'll have to enable "Provide build settings from" to inherit the `$SRCROOT` environment variable.
+If you don't want to prefix your commands with `mise x -C $SRCROOT`, you can add the shims directory to the `$PATH` environment variable:
+
+```bash
+export PATH="$HOME/.local/bin/bin:$PATH"
+export PATH="$HOME/.local/share/mise/shims:$PATH"
+
+mise reshim -C $SRCROOT
+swiftlint
+```
+
+
+::: tip NOTE
+The `mise reshim` command is important to ensure Mise creates shims for the tools and versions specified in the project's Mise configuration file. Otherwise the script might end up using other versions of the tools.
+:::
+
 
 ## [YOUR IDE HERE]
 

--- a/ide-integration.md
+++ b/ide-integration.md
@@ -53,7 +53,7 @@ swiftlint
 
 
 ::: tip NOTE
-The `mise reshim` command is important to ensure Mise creates shims for the tools and versions specified in the project's Mise configuration file. Otherwise the script might end up using other versions of the tools.
+The `mise reshim` command is important to ensure mise creates shims for the tools and versions specified in the project's mise configuration file. Otherwise the script might end up using other versions of the tools.
 :::
 
 

--- a/ide-integration.md
+++ b/ide-integration.md
@@ -44,7 +44,7 @@ mise x -C $SRCROOT swiftlint
 If you don't want to prefix your commands with `mise x -C $SRCROOT`, you can add the shims directory to the `$PATH` environment variable:
 
 ```bash
-export PATH="$HOME/.local/bin/bin:$PATH"
+export PATH="$HOME/.local/bin:$PATH"
 export PATH="$HOME/.local/share/mise/shims:$PATH"
 
 mise reshim -C $SRCROOT


### PR DESCRIPTION
It turns out that Xcode uses `/usr/bin/sandbox-exec` to run the build scripts, ensuring that the script only has access to a limited (and configurable) set of files in the file system. Therefore, it's required for `$SRCROOT/.mise.toml` to be listed in the list of input files for `mise install -C $SRCROOT` to work (`$SRCROOT` points to the root directory containing the project). Otherwise, the command fails due to permission errors.

This PR adjusts the documentation accordingly, and also includes an alternative path for developers that don't want to be prefixing their commands with `mise x`