### PR TITLE
Correcting Names and Links for rtx-plugins

### DIFF
--- a/lang/go.md
+++ b/lang/go.md
@@ -4,7 +4,6 @@ The following are instructions for using the go mise core plugin. This is used w
 git plugin installed named "go".
 
 If you want to use [asdf-golang](https://github.com/kennyp/asdf-golang)
-or [rtx-golang](https://github.com/mise-plugins/rtx-golang)
 then use `mise plugins install go GIT_URL`.
 
 The code for this is inside the mise repository at

--- a/lang/go.md
+++ b/lang/go.md
@@ -4,7 +4,7 @@ The following are instructions for using the go mise core plugin. This is used w
 git plugin installed named "go".
 
 If you want to use [asdf-golang](https://github.com/kennyp/asdf-golang)
-or [mise-golang](https://github.com/rtx-plugins/mise-golang)
+or [rtx-golang](https://github.com/mise-plugins/rtx-golang)
 then use `mise plugins install go GIT_URL`.
 
 The code for this is inside the mise repository at
@@ -19,7 +19,7 @@ installed) and makes it the global default:
 mise use -g go@1.21
 ```
 
-Minor go versions 1.20 and below require specifying `prefix` before the version number because the first version 
+Minor go versions 1.20 and below require specifying `prefix` before the version number because the first version
 of each serie was released without a `.0` suffix, making 1.20 an exact version match:
 
 ```sh

--- a/lang/java.md
+++ b/lang/java.md
@@ -4,7 +4,6 @@ The following are instructions for using the java mise core plugin. This is used
 git plugin installed named "java".
 
 If you want to use [asdf-java](https://github.com/halcyon/asdf-java)
-or [rtx-java](https://github.com/mise-plugins/rtx-java)
 then use `mise plugins install java GIT_URL`.
 
 The code for this is inside the mise repository at

--- a/lang/java.md
+++ b/lang/java.md
@@ -4,7 +4,7 @@ The following are instructions for using the java mise core plugin. This is used
 git plugin installed named "java".
 
 If you want to use [asdf-java](https://github.com/halcyon/asdf-java)
-or [mise-java](https://github.com/rtx-plugins/mise-java)
+or [rtx-java](https://github.com/mise-plugins/rtx-java)
 then use `mise plugins install java GIT_URL`.
 
 The code for this is inside the mise repository at

--- a/lang/node.md
+++ b/lang/node.md
@@ -3,7 +3,7 @@
 The following are instructions for using the node mise core plugin. This is used when there isn't a
 git plugin installed named "node".
 
-If you want to use [asdf-nodejs](https://github.com/asdf-vm/asdf-nodejs) 
+If you want to use [asdf-nodejs](https://github.com/asdf-vm/asdf-nodejs)
 then run `mise plugins install node https://github.com/asdf-vm/asdf-nodejs`
 
 The code for this is inside the mise repository at [`./src/plugins/core/node.rs`](https://github.com/jdx/mise/blob/main/src/plugins/core/node.rs).

--- a/lang/ruby.md
+++ b/lang/ruby.md
@@ -4,7 +4,6 @@ The following are instructions for using the ruby mise core plugin. This is used
 git plugin installed named "ruby".
 
 If you want to use [asdf-ruby](https://github.com/asdf-vm/asdf-ruby)
-or [rtx-ruby](https://github.com/mise-plugins/rtx-ruby)
 then use `mise plugins install ruby GIT_URL`.
 
 The code for this is inside the mise repository at

--- a/lang/ruby.md
+++ b/lang/ruby.md
@@ -4,7 +4,7 @@ The following are instructions for using the ruby mise core plugin. This is used
 git plugin installed named "ruby".
 
 If you want to use [asdf-ruby](https://github.com/asdf-vm/asdf-ruby)
-or [mise-ruby](https://github.com/rtx-plugins/mise-ruby)
+or [rtx-ruby](https://github.com/mise-plugins/rtx-ruby)
 then use `mise plugins install ruby GIT_URL`.
 
 The code for this is inside the mise repository at


### PR DESCRIPTION
The organization for rtx-plugins is mise-plugins, but the individual repository names remain as 'rtx.' This pull request addresses this inconsistency by making the necessary corrections.