### PR TITLE
docs: fix broken link

### DIFF
--- a/dev-tools/comparison-to-asdf.md
+++ b/dev-tools/comparison-to-asdf.md
@@ -7,7 +7,7 @@ you may have used with asdf and uses asdf plugins. It will not, however, reuse e
 Casual users coming from asdf have generally found mise to just be a faster, easier to use asdf.
 
 :::tip
-Make sure you have a look at [environments[(/environments) and [tasks](/tasks/) which
+Make sure you have a look at [environments](/environments.html) and [tasks](/tasks/) which
 are major portions of mise that have no asdf equivalent.
 :::
 


### PR DESCRIPTION
There seem to be an unmatched `[` in the link to the environments page.

I saw the actual page used `.html` so I added this is, not sure if it should be just `[environments](/environments/)`?