### PR TITLE
Improve documentation for setting up development environments and default installs with mise

### DIFF
--- a/lang/node.md
+++ b/lang/node.md
@@ -41,9 +41,9 @@ required system dependencies.
 mise-node can automatically install a default set of npm packages right after installing a node version. To enable this feature, provide a `$HOME/.default-npm-packages` file that lists one package per line, for example:
 
 ```text
-lodash
-request
-express
+@angular/cli
+mocha
+typescript-language-server
 ```
 
 You can specify a non-default location of this file by setting a `MISE_NODE_DEFAULT_PACKAGES_FILE` variable.

--- a/lang/python.md
+++ b/lang/python.md
@@ -147,6 +147,14 @@ CFLAGS="-I$(brew --prefix openssl)/include" \
 brew link pkg-config
 ```
 
+## Setting Up PyCharm to Use the Appropriate Base Python on macOS
+
+To instruct PyCharm to prioritize your Python3 installation over the system's Python install, you can execute the command below:
+
+```sh
+sudo ln -s ~/.local/share/mise/installs/python/latest/bin/python3 /usr/local/bin/python3
+```
+
 ## Automatic virtualenv activation <Badge type="warning" text="experimental" />
 
 Python comes with virtualenv support built in, use it with `.mise.toml` configuration like

--- a/lang/python.md
+++ b/lang/python.md
@@ -152,7 +152,7 @@ brew link pkg-config
 To instruct PyCharm to prioritize your Python3 installation over the system's Python install, you can execute the command below:
 
 ```sh
-sudo ln -s ~/.local/share/mise/installs/python/latest/bin/python3 /usr/local/bin/python3
+sudo ln -s ~/.local/share/mise/installs/python/3/bin/python3 /usr/local/bin/python3
 ```
 
 ## Automatic virtualenv activation <Badge type="warning" text="experimental" />


### PR DESCRIPTION
Improved instructions for setting up PyCharm in python.md
   - Provided clearer instructions on how to prioritize Python3 installation over the system’s Python install in PyCharm on macOS.

Update default npm packages in node.md
   - Updated the list of default npm packages, removed outdated ones, and added common global packages with various naming schemes. This showcases different syntax's for packages.