### PR TITLE
Fix Xcode Cloud code snippet

### DIFF
--- a/continuous-integration.md
+++ b/continuous-integration.md
@@ -63,7 +63,7 @@ If you are using Xcode Cloud, you can use custom `ci_post_clone.sh` [build scrip
 ```bash
 #!/bin/sh
 curl https://mise.run | sh
-export PATH="$HOME/.local/bin/bin:$PATH"
+export PATH="$HOME/.local/bin:$PATH"
 
 mise install # Installs the tools in .mise.toml
 eval "$(mise activate bash --shims)" # Addds the activated tools to $PATH


### PR DESCRIPTION
I [noticed](https://github.com/tuist/tuist/issues/5863#issuecomment-1928989811) the steps to set up Mise in Xcode Cloud tell users to set the wrong path in the `$PATH` environment variable. This PR fixes it.